### PR TITLE
Expose draws `private_id` in the swagger docs

### DIFF
--- a/eas/api/serializers.py
+++ b/eas/api/serializers.py
@@ -20,7 +20,7 @@ class DrawMetadataSerializer(serializers.ModelSerializer):
 
 class BaseSerializer(serializers.ModelSerializer):
     BASE_FIELDS = (*COMMON_FIELDS, 'updated_at', 'title', 'description',
-                   'results', 'metadata',)
+                   'results', 'metadata', 'private_id')
 
     results = serializers.SerializerMethodField()
     metadata = DrawMetadataSerializer(many=True, required=False)

--- a/eas/api/tests/test_serializers.py
+++ b/eas/api/tests/test_serializers.py
@@ -13,7 +13,7 @@ class TestSerializers(TestCase):
         res = RandomNumberSerializer(self.draw).data
 
         self.assertEqual(sorted(res), sorted([
-            'id', 'created_at', 'updated_at', 'title',
+            'id', 'private_id', 'created_at', 'updated_at', 'title',
             'description', 'results', 'metadata',
             'range_min', 'range_max',
         ]))


### PR DESCRIPTION
Add `private_id` to the serializer to it shows up in swagger. Rather than adding it dynamically to the draws that have the owner the code will instead remove it when the user is not the owner of the draw.

Closes #13