### PR TITLE
Update random number to generate results as a list

### DIFF
--- a/eas/api/models.py
+++ b/eas/api/models.py
@@ -71,7 +71,7 @@ class RandomNumber(BaseDraw):
     range_max = models.IntegerField()
 
     def generate_result(self):
-        return random.randint(self.range_min, self.range_max)
+        return [random.randint(self.range_min, self.range_max)]
 
 
 class Participant(BaseModel):

--- a/eas/api/tests/test_models.py
+++ b/eas/api/tests/test_models.py
@@ -22,7 +22,7 @@ class TestModels(TestCase):
         draw.toss()
 
         self.assertEqual(
-            1,
+            [1],
             self.get_random_number(draw.id).results.first().value
         )
 


### PR DESCRIPTION
The schema already defines the result value type as a list of integers and this will allow the future enhancement of allowing to generate multiple results in a single toss.