### PR TITLE
Add support for scheduling a toss

### DIFF
--- a/eas/api/serializers.py
+++ b/eas/api/serializers.py
@@ -9,7 +9,7 @@ COMMON_FIELDS = ('id', 'created_at',)
 
 
 class DrawTossPayloadSerializer(serializers.Serializer):
-    pass
+    schedule_date = serializers.DateTimeField(allow_null=True, required=False)
 
 
 class DrawMetadataSerializer(serializers.ModelSerializer):
@@ -46,9 +46,9 @@ class BaseSerializer(serializers.ModelSerializer):
 class ResultSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Result
-        fields = ('created_at', 'value',)
+        fields = ('created_at', 'value', 'schedule_date',)
 
-    value = serializers.JSONField()
+    value = serializers.JSONField(allow_null=True)
 
 
 class RandomNumberSerializer(BaseSerializer):

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -223,7 +223,10 @@ definitions:
           $ref: '#/definitions/Participant'
   DrawTossPayload:
     type: object
-    properties: {}
+    properties:
+      schedule_date:
+        type: string
+        format: date-time
   RandomNumber:
     required:
       - range_min
@@ -276,6 +279,9 @@ definitions:
         type: string
         format: date-time
         readOnly: true
+      schedule_date:
+        type: string
+        format: date-time
       value:
         type: object
         properties:
@@ -299,6 +305,9 @@ definitions:
         type: string
         format: date-time
         readOnly: true
+      schedule_date:
+        type: string
+        format: date-time
       value:
         type: array
         items:


### PR DESCRIPTION
Support clients to schedule a toss rather than requesting an immediate one. The toss is resolved at retrieve time as a compromise to keep the implementation simple and not having to add other background processes.

Closes #2 