### PR TITLE
Add endpoint to add participants to an existing raffle

### DIFF
--- a/eas/api/tests/int/test_raffle.py
+++ b/eas/api/tests/int/test_raffle.py
@@ -54,3 +54,29 @@ class TestRaffle(DrawAPITestMixin, APILiveServerTestCase):
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST,
                          response.content)
+
+    def test_add_participants(self):
+        draw = self.Factory(participants=[])
+        assert not draw.participants
+
+        url = reverse(f'{self.base_url}-participants',
+                      kwargs=dict(pk=draw.id))
+        response = self.client.post(url, {
+            "name": "paco",
+        })
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED,
+                         response.content)
+        draw = self.get_draw(draw.id)
+        assert len(draw.participants) == 1
+        assert draw.participants[0].name == "paco"
+
+        response = self.client.post(url, {
+            "name": "ramon",
+            "facebook_id": "this_is_an_id"
+        })
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED,
+                         response.content)
+        draw = self.get_draw(draw.id)
+        assert len(draw.participants) == 2
+        assert draw.participants[1].name == "ramon"
+        assert draw.participants[1].facebook_id == "this_is_an_id"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -62,6 +62,25 @@ paths:
         in: path
         required: true
         type: string
+  '/raffle/{id}/participants/':
+    post:
+      operationId: raffle_participants_add
+      parameters:
+        - name: data
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Participant'
+      responses:
+        '201':
+          description: Object created
+      tags:
+        - raffle
+    parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
   /random_number/:
     post:
       operationId: random_number_create
@@ -284,7 +303,7 @@ definitions:
         format: date-time
       value:
         type: array
-        items: 
+        items:
           type: object
           properties:
             participant:


### PR DESCRIPTION
This will be used for the raffles where the list of participants is not fixed since the beginning and are added after its creation.

Closes #24 