### PR TITLE
Remove swagger generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ pylint eas
 ./manage.py runserver
 ```
 
-Check `/api/swagger` or `/api/redoc`.
+#### Working on the swagger file
 
-Swagger file available in `/api/swagger.yaml` or by running
 ```bash
-./manage.py generate_swagger
+docker pull swaggerapi/swagger-editor
+docker run -d -p 8080:8080 swaggerapi/swagger-editor
 ```
 
 #### Run dev version

--- a/eas/api/urls.py
+++ b/eas/api/urls.py
@@ -1,6 +1,3 @@
-from django.urls import re_path
-from drf_yasg import openapi
-from drf_yasg.views import get_schema_view
 from rest_framework.routers import DefaultRouter
 
 from . import views
@@ -15,24 +12,3 @@ router.register(r'random_number', views.RandomNumberViewSet,
 router.register(r'raffle', views.RaffleViewSet,
                 base_name='raffle')
 urlpatterns = router.urls
-
-# schema definition
-api_info = openapi.Info(
-    title="EAS API",
-    default_version="v1",
-)
-
-schema_view = get_schema_view(
-    api_info,
-    validators=['flex', 'ssv'],
-    public=True,
-)
-
-urlpatterns += [
-    re_path(r'^swagger(?P<format>\.json|\.yaml)$',
-            schema_view.without_ui(cache_timeout=None), name='schema-json'),
-    re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=None),
-            name='schema-swagger-ui'),
-    re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=None),
-            name='schema-redoc'),
-]

--- a/eas/api/views.py
+++ b/eas/api/views.py
@@ -6,7 +6,6 @@ from rest_framework import mixins, viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
-from drf_yasg.utils import swagger_auto_schema
 
 from . import models, serializers
 
@@ -53,8 +52,6 @@ class BaseDrawViewSet(mixins.CreateModelMixin,
         LOG.info("Returning draw %s", instance)
         return Response(result_data)
 
-    @swagger_auto_schema(methods=['post'],
-                         request_body=serializers.DrawTossPayloadSerializer)
     @action(methods=['post'], detail=True)
     def toss(self, request, pk):
         LOG.info("Tossing draw with id: %s", pk)

--- a/eas/settings/base.py
+++ b/eas/settings/base.py
@@ -33,7 +33,6 @@ DJANGO_APPS = [
 
 
 THIRD_PRATY_APPS = [
-    'drf_yasg',
     'rest_framework',
 ]
 


### PR DESCRIPTION
Remove all code that generates the UI from the source code.
As we now have the swagger file we should just server the swagger ui
from the file.

Closes #16 