### PR TITLE
Fix return type of letter and random number

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -729,10 +729,7 @@ components:
               nullable: true
               type: array
               items:
-                type: array
-                nullable: true
-                items:
-                  type: integer
+                type: integer
     LetterResult:
       allOf:
         - $ref: '#/components/schemas/BaseResult'
@@ -742,10 +739,7 @@ components:
               nullable: true
               type: array
               items:
-                type: array
-                nullable: true
-                items:
-                  type: string
+                type: string
     SpinnerResult:
       allOf:
         - $ref: '#/components/schemas/BaseResult'


### PR DESCRIPTION
Probably from a copy paste from the groups draw, the type is of the result value element was set to an array of arrays.
Fixed to just be an array.

Closes #42