### PR TITLE
Remove `ALLOWED_HOSTS` from settings.prod

### DIFF
--- a/eas/settings/prod.py
+++ b/eas/settings/prod.py
@@ -1,8 +1,6 @@
 """Production deployment settings"""
 from .base import *
 
-ALLOWED_HOSTS = []
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',


### PR DESCRIPTION
We have configured all domains in the base, as we are allowing everything within a subdomain there is no need to have settings per environment.