### PR TITLE
Fix internal error when some random_number args are not provided

### DIFF
--- a/eas/api/serializers.py
+++ b/eas/api/serializers.py
@@ -65,8 +65,8 @@ class RandomNumberSerializer(BaseSerializer):
         num_values_in_range = data["range_max"] - data["range_min"]
         if num_values_in_range < 1:
             raise serializers.ValidationError('invalid_range')
-        if not data["allow_repeated_results"] and (
-                data["number_of_results"] > num_values_in_range):
+        if not data.get("allow_repeated_results", True) and (
+                data.get("number_of_results", 1) > num_values_in_range):
             raise serializers.ValidationError('invalid_range')
         return data
 

--- a/eas/api/tests/int/test_random_number.py
+++ b/eas/api/tests/int/test_random_number.py
@@ -29,6 +29,14 @@ class TestRandomNumber(DrawAPITestMixin, APILiveServerTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST,
                          response.content)
 
+    def test_creation_miss_optional_fields(self):
+        url = reverse(f'{self.base_url}-list')
+        data = self.Factory.dict(range_min=1, range_max=4)
+        data.pop("allow_repeated_results")
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+
     def test_creation_invalid_repeated(self):
         url = reverse(f'{self.base_url}-list')
         data = self.Factory.dict(range_min=1, range_max=10,


### PR DESCRIPTION
As the values are defaulted in the API we did not check that they can be not present at the time we validate them in the serializer.