### PR TITLE
Move requirement to `psycopg2-binary` from `psycopg2`

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,3 @@
 -r base.txt
 gunicorn==19.6.0
-psycopg2==2.7.5
+psycopg2-binary==2.7.5


### PR DESCRIPTION
The psycopg2 is branching into two flavors, sdist and wheel. Whilst both were provided within the same package before, the wheel is now only present in `psycopg2`. This commit moves the project to the binary package as it is more convenient. There are reports of the binary segfaulting under certain conditions, should those arise in the project we should move to the sdist and add the system dependency on the library it needs to compile.

For further info, check:
http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released/
or issue #38

Closes #38