### PR TITLE
Configure Sentry to report errors

### DIFF
--- a/eas/settings/dev.py
+++ b/eas/settings/dev.py
@@ -1,2 +1,4 @@
 """Settings for deployment to the DEV/TEST server"""
 from .prod import *
+
+RAVEN_CONFIG['environment'] = 'dev'

--- a/eas/settings/prod.py
+++ b/eas/settings/prod.py
@@ -1,4 +1,8 @@
 """Production deployment settings"""
+import os
+
+import raven
+
 from .base import *
 
 DATABASES = {
@@ -9,4 +13,17 @@ DATABASES = {
         'HOST': 'db',
         'PORT': 5432,
     }
+}
+
+
+# Sentry config
+INSTALLED_APPS = [
+    *INSTALLED_APPS,
+    'raven.contrib.django.raven_compat',
+]
+
+RAVEN_CONFIG = {
+    'dsn': os.environ.get('SENTRY_DSN'),
+    'release': raven.fetch_git_sha(ROOT_DIR),
+    'environment': 'prod',
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,3 +3,4 @@ djangorestframework==3.8.2
 drf-yasg[validation]==1.9.1
 jsonfield==2.0.2
 pytz==2018.5
+raven==6.9.0


### PR DESCRIPTION
Configure sentry to report errors to the framework that will trigger emails with information about the incident. An environment variable is needed to configure sentry, it has to be set on startup.

Closes #10 