### PR TITLE
Make explicit that basePath is not used

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3,7 +3,7 @@ info:
   title: EAS API
   version: 0.0.1
 servers:
-  - url: '/api'
+  - url: '/should-be-overriden'
 paths:
   /groups/:
     post:


### PR DESCRIPTION
This needs no be overriden in the clients