### PR TITLE
ci: Check for pending migrations rather than running them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - pip install -r requirements/local.txt
 
 script:
-  - python manage.py makemigrations
+  - python manage.py makemigrations --check --dry-run -v2
   - coverage run manage.py test
   - coverage report
 


### PR DESCRIPTION
The CI was wrongly running makemigrations rather than running them.
The migrations should be available, makemigration might have make the
tests pass in the past because they were not run.