### PR TITLE
Don't hard fail if unable to get local IP

### DIFF
--- a/eas/settings/base.py
+++ b/eas/settings/base.py
@@ -19,12 +19,22 @@ APP_DIR = ROOT_DIR / 'eas'
 
 DEBUG = False
 
+_local_ips = [
+    "127.0.0.1",
+]
+
+try:
+    _local_ips.append(
+        socket.gethostbyname(socket.gethostname()),  # IP
+    )
+except socket.gaierror:
+    pass
+
 ALLOWED_HOSTS = [
     '.echaloasuerte.com',
     '.woreep.com',
     '.chooserandom.com',
-    socket.gethostbyname(socket.gethostname()),  # IP
-    '127.0.0.1',
+    *_local_ips,
 ]
 
 # Application definition


### PR DESCRIPTION
Ignore the exception that can be raised if the host is unable to find
the local IP. This can happen if for example gethostname returns a name
that is mapped to an IPv6 address, which is not supported by
gethostbyname.