### PR TITLE
Fix number of results limit in Letter draw

### DIFF
--- a/eas/api/serializers.py
+++ b/eas/api/serializers.py
@@ -78,7 +78,13 @@ class LetterSerializer(BaseSerializer):
             'number_of_results', 'allow_repeated_results',
         )
 
-    number_of_results = serializers.IntegerField(min_value=1, max_value=26)
+    number_of_results = serializers.IntegerField(min_value=1)
+
+    def validate(self, data):  # pylint: disable=arguments-differ
+        if not data.get("allow_repeated_results", False) and (
+                data.get("number_of_results", 1) > 26):
+            raise serializers.ValidationError('invalid_number_of_results')
+        return data
 
 
 class PrizeSerializer(serializers.ModelSerializer):

--- a/eas/api/tests/int/test_letter.py
+++ b/eas/api/tests/int/test_letter.py
@@ -26,3 +26,11 @@ class TestLetter(DrawAPITestMixin, APILiveServerTestCase):
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST,
                          response.content)
+
+
+    def test_creation_valid(self):
+        url = reverse(f'{self.base_url}-list')
+        data = self.Factory.dict(number_of_results=27, allow_repeated_results=True)
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED,
+                         response.content)


### PR DESCRIPTION
If an user specifies that results can be repeated we can remove
altogether the upper bound on the number of results.