### PR TITLE
Set an arbitrary value for Letter number_of_results

### DIFF
--- a/eas/api/serializers.py
+++ b/eas/api/serializers.py
@@ -102,7 +102,7 @@ class LetterSerializer(BaseSerializer):
             "allow_repeated_results",
         )
 
-    number_of_results = serializers.IntegerField(min_value=1)
+    number_of_results = serializers.IntegerField(min_value=1, max_value=200)
 
     def validate(self, data):  # pylint: disable=arguments-differ
         if not data.get("allow_repeated_results", False) and (


### PR DESCRIPTION
This will prevent generating an internal error if an user requests a
million random letters.