### PR TITLE
Allow toss a raffle with insufficient results

### DIFF
--- a/eas/api/models.py
+++ b/eas/api/models.py
@@ -199,7 +199,8 @@ class Raffle(BaseDraw, PrizesMixin, ParticipantsMixin):
         )
         random.shuffle(participants)
         for prize, winner in zip(
-            self.prizes.values(*PrizesMixin.SERIALIZE_FIELDS), participants
+            self.prizes.values(*PrizesMixin.SERIALIZE_FIELDS),
+            itertools.cycle(participants),
         ):
             result.append(
                 {

--- a/eas/api/views.py
+++ b/eas/api/views.py
@@ -114,7 +114,7 @@ class RaffleViewSet(BaseDrawViewSet, ParticipantsMixin):
     queryset = MODEL.objects.all()
 
     def _ready_to_toss_check(self, draw):  # pylint: disable=no-self-use
-        if draw.participants.count() < draw.prizes.count():
+        if not draw.participants.count():
             raise ValidationError(
                 f"The draw needs to have at least {draw.prizes.count()}"
                 " participants."


### PR DESCRIPTION
We will just repeat the participants as that is the most intuitive
action for organizers.

Closes https://github.com/etcaterva/eas-frontend/issues/193