### PR TITLE
Disable admin in production

### DIFF
--- a/eas/settings/prod.py
+++ b/eas/settings/prod.py
@@ -5,6 +5,8 @@ import raven
 
 from .base import *
 
+ADMIN_ENABLED = False
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",


### PR DESCRIPTION
We can enable this if we ever need it.

Closes https://github.com/etcaterva/eas-backend/issues/77

If we ever need the admin panel we just need to re-enable this and create a user.