### PR TITLE
Translate error message to make them easier to consume

### DIFF
--- a/eas/api/error_handler.py
+++ b/eas/api/error_handler.py
@@ -1,0 +1,18 @@
+from django.http import JsonResponse
+from rest_framework.exceptions import ValidationError
+from rest_framework.views import exception_handler
+
+
+def drf_validation_handler(exc, context):
+    response = exception_handler(exc, context)
+    if isinstance(exc, ValidationError):
+        detail = exc.get_full_details()
+        response_payload = {}
+        if isinstance(detail, (list, tuple)):
+            response_payload = {"general": detail}
+        elif isinstance(detail, dict):
+            response_payload = {"schema": detail}
+        else:  # pragma: no cover
+            return response
+        return JsonResponse(response_payload, safe=False, status=response.status_code)
+    return response  # pragma: no cover

--- a/eas/api/tests/int/test_secret_santa.py
+++ b/eas/api/tests/int/test_secret_santa.py
@@ -87,6 +87,9 @@ class SecretSantaTest(APILiveServerTestCase):
         self.assertEqual(
             response.status_code, status.HTTP_400_BAD_REQUEST, response.content
         )
+        assert response.json() == {
+            "general": [{"message": "Unable to match participants", "code": "invalid"}]
+        }
 
     def test_retrieve(self):
         result = models.SecretSantaResult(source="From name", target="To Name")
@@ -95,3 +98,20 @@ class SecretSantaTest(APILiveServerTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         self.assertEqual(response.data, {"source": "From name", "target": "To Name"})
+
+    def test_missing_fields(self):
+        secret_santa_data = {}
+        response = self.client.post(self.list_url, secret_santa_data)
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST, response.content
+        )
+        assert response.json() == {
+            "schema": {
+                "participants": [
+                    {"message": "This field is required.", "code": "required"}
+                ],
+                "language": [
+                    {"message": "This field is required.", "code": "required"}
+                ],
+            }
+        }

--- a/eas/api/views.py
+++ b/eas/api/views.py
@@ -237,7 +237,7 @@ class SecretSantaSet(
             target = emails_map[source]
             try:
                 email.send_secret_santa_mail(target, result.id, data["language"])
-            except Exception:
+            except Exception:  # pragma: no cover  # pylint: disable=broad-except
                 LOG.exception("Failed to send email to %s", target)
         LOG.info("Created secret santa results %s", results)
         headers = self.get_success_headers(serializer.data)

--- a/eas/settings/base.py
+++ b/eas/settings/base.py
@@ -200,7 +200,10 @@ DEFAULT_RENDERER_CLASSES = [
     "rest_framework.renderers.JSONRenderer",
 ]  # use append, dont just override this varible
 
-REST_FRAMEWORK = {"DEFAULT_RENDERER_CLASSES": DEFAULT_RENDERER_CLASSES}
+REST_FRAMEWORK = {
+    "DEFAULT_RENDERER_CLASSES": DEFAULT_RENDERER_CLASSES,
+    "EXCEPTION_HANDLER": "eas.api.error_handler.drf_validation_handler",
+}
 
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"


### PR DESCRIPTION
This will facilitate consuming them on the frontend.

closes #95 