### PR TITLE
Send emails asynchronously

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ source =
 omit =
     eas/wsgi.py
     eas/settings/*py
+    celery-task.py
 
 [report]
 show_missing = True

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ EAS Backend services
 #### Set up local environment
 
 ```bash
+sudo apt-get install rabbitmq-server
 python3.6 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements/local.txt
@@ -25,6 +26,13 @@ make test
 
 ```bash
 make runlocal
+```
+
+Optionally, run the following to get emails working:
+
+```bash
+docker run -d -p 5672:5672 rabbitmq
+EAS_MAIL_PASSWORD="<set password>" celery --app celery-task worker
 ```
 
 #### Working on the swagger file

--- a/celery-task.py
+++ b/celery-task.py
@@ -1,0 +1,12 @@
+import os
+
+from celery import Celery
+from django.conf import settings
+
+if not os.environ.get("DJANGO_SETTINGS_MODULE"):
+    raise RuntimeError("Set 'DJANGO_SETTINGS_MODULE' env variable")
+
+
+app = Celery(broker=settings.CELERY_BROKER_URL)
+app.config_from_object("django.conf:settings")
+app.autodiscover_tasks(settings.INSTALLED_APPS)

--- a/eas/api/email.py
+++ b/eas/api/email.py
@@ -1,6 +1,5 @@
 import copy
 
-from django.conf import settings
 from django.core.mail import EmailMessage
 from django.template import loader
 
@@ -41,9 +40,8 @@ def send_secret_santa_mail(to, result_id, language):  # pragma: no cover
         subject=subject,
         body=content,
         to=[to],
-        from_email=settings.EMAIL_HOST_USER,
-        reply_to=[settings.EMAIL_HOST_USER],
-        headers={"Content-Type": "text/html"},
+        from_email="no-reply@echaloasuerte.com",
+        reply_to=["no-reply@echaloasuerte.com"],
     )
     email.content_subtype = "html"
     email.send()

--- a/eas/api/serializers.py
+++ b/eas/api/serializers.py
@@ -264,7 +264,7 @@ class SecretSantaParticipantSerializer(serializers.Serializer):
 
 class SecretSantaSerializer(serializers.Serializer):
     participants = serializers.ListField(
-        child=SecretSantaParticipantSerializer(), min_length=3, max_length=500
+        child=SecretSantaParticipantSerializer(), min_length=3, max_length=100
     )
     language = serializers.ChoiceField(choices=["es", "en"])
 

--- a/eas/api/views.py
+++ b/eas/api/views.py
@@ -233,6 +233,7 @@ class SecretSantaSet(
                 break
         else:
             raise ValidationError("Unable to match participants")
+        LOG.info("Sending %s secret santa emails", len(results))
         for source, target in results:
             result = models.SecretSantaResult(source=source, target=target)
             result.save()

--- a/eas/settings/base.py
+++ b/eas/settings/base.py
@@ -208,8 +208,8 @@ REST_FRAMEWORK = {
 
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = "smtp.zoho.com"
-EMAIL_HOST_USER = "no-reply@echaloasuerte.com"
+EMAIL_HOST = "email-smtp.us-east-2.amazonaws.com"
+EMAIL_HOST_USER = "AKIA5YJYF55GBYNVGYCH"
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False

--- a/eas/settings/base.py
+++ b/eas/settings/base.py
@@ -53,6 +53,7 @@ DJANGO_APPS = [
 
 THIRD_PRATY_APPS = [
     "rest_framework",
+    "djcelery_email",
 ]
 
 LOCAL_APPS = [
@@ -206,13 +207,15 @@ REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "eas.api.error_handler.drf_validation_handler",
 }
 
-
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = "email-smtp.us-east-2.amazonaws.com"
 EMAIL_HOST_USER = "AKIA5YJYF55GBYNVGYCH"
+EMAIL_BACKEND = "djcelery_email.backends.CeleryEmailBackend"
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False
 EMAIL_HOST_PASSWORD = os.environ.get("EAS_MAIL_PASSWORD")
+
+CELERY_EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+CELERY_BROKER_URL = "amqp://guest:guest@localhost:5672/"
 
 PAYPAL_SECRET = os.environ.get("EAS_PAYPAL_SECRET", "paypal-secret-unset")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,14 +4,24 @@
 #
 #    pip-compile --no-annotate --output-file=requirements/base.txt requirements/base.orig.txt requirements/base.txt
 #
+amqp==5.0.6
 attrs==20.3.0
+billiard==3.6.4.0
+cached-property==1.5.2
+celery==5.1.2
 certifi==2020.12.5
 cffi==1.14.5
 chardet==4.0.0
+click==7.1.2
+click-didyoumean==0.3.0
+click-plugins==1.1.1
+click-repl==0.2.0
 coreapi==2.3.3
 coreschema==0.0.4
 cryptography==3.4.6
 django==2.2.24
+django-appconf==1.0.5
+django-celery-email==3.0.0
 djangorestframework==3.11.2
 drf-yasg[validation]==1.17.0
 idna==2.10
@@ -21,9 +31,11 @@ itypes==1.2.0
 jinja2==2.11.3
 jsonfield==2.0.2
 jsonschema==3.2.0
+kombu==5.1.0
 markupsafe==1.1.1
 packaging==20.9
 paypalrestsdk==1.13.1
+prompt-toolkit==3.0.21
 pycparser==2.20
 pyopenssl==20.0.1
 pyparsing==2.4.7
@@ -41,6 +53,8 @@ swagger-spec-validator==2.7.3
 typing-extensions==3.7.4.3
 uritemplate==3.0.1
 urllib3==1.26.5
+vine==5.0.0
+wcwidth==0.2.5
 zipp==3.4.0
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Use celery to send emails asyncronously. This will allow to handle
secret santa draws with a high number of participants. Without this, the
server waits synchronously for the emails to be sent, timesouts and
harakiri will finalize the web backend process.

Closes #101 