### PR TITLE
Include range_min and range_max in RandomNumber validation

### DIFF
--- a/eas/api/serializers.py
+++ b/eas/api/serializers.py
@@ -97,7 +97,8 @@ class RandomNumberSerializer(BaseSerializer):
     number_of_results = serializers.IntegerField(min_value=1, max_value=50)
 
     def validate(self, data):  # pylint: disable=arguments-differ
-        num_values_in_range = data["range_max"] - data["range_min"]
+        num_values_in_range = data["range_max"] - data["range_min"] + 1
+
         if num_values_in_range < 1:
             raise serializers.ValidationError("invalid_range")
         if not data.get("allow_repeated_results", True) and (

--- a/eas/api/tests/int/test_random_number.py
+++ b/eas/api/tests/int/test_random_number.py
@@ -23,7 +23,13 @@ class TestRandomNumber(DrawAPITestMixin, APILiveServerTestCase):
             "allow_repeated_results": draw.allow_repeated_results,
         }
 
-    def test_creation_invalid(self):
+    def test_creation_valid_range(self):
+        response = self.create(range_min=1, range_max=2, number_of_results=2)
+        self.assertEqual(
+            response.status_code, status.HTTP_201_CREATED, response.content
+        )
+
+    def test_creation_invalid_range(self):
         response = self.create(range_min=5, range_max=4)
         self.assertEqual(
             response.status_code, status.HTTP_400_BAD_REQUEST, response.content
@@ -36,8 +42,16 @@ class TestRandomNumber(DrawAPITestMixin, APILiveServerTestCase):
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-    def test_creation_invalid_repeated(self):
-        response = self.create(range_min=1, range_max=10, number_of_results=10)
+    def test_creation_invalid_without_repeated(self):
+        response = self.create(range_min=1, range_max=2, number_of_results=10)
         self.assertEqual(
             response.status_code, status.HTTP_400_BAD_REQUEST, response.content
+        )
+
+    def test_creation_valid_with_repeated(self):
+        response = self.create(
+            range_min=1, range_max=2, number_of_results=10, allow_repeated_results=True
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_201_CREATED, response.content
         )


### PR DESCRIPTION
That's the way we expect it to behave, and its already how [randint](https://docs.python.org/3/library/random.html#random.randint) works, including both the initial and end value.


I image that the use case for this is generating a shuffled list of numbers from A to B, which I guess is a valid use case

Please review if the tests make sense