### PR TITLE
Fix post_url param in swagger

### DIFF
--- a/eas/api/views.py
+++ b/eas/api/views.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import urllib.parse
 
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
@@ -309,7 +310,8 @@ def paypal_accept(request):
 
 @api_view(["GET"])
 def instagram_preview(request):
-    post_url = request.GET["post_url"]
+    encoded_post_url = request.GET["post_url"]
+    post_url = urllib.parse.unquote(encoded_post_url)
     LOG.info("Fetching instagram preview for %r", post_url)
     data = instagram.get_post_info(post_url)
     LOG.info("Fetched post information: %r", data)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -660,12 +660,6 @@ paths:
   '/instagram-preview/':
     post:
       operationId: instagram_preview
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/InstagramPreviewPayload'
-        required: true
       responses:
         '200':
           description: Previews the information of an instagram post
@@ -675,6 +669,12 @@ paths:
                 $ref: '#/components/schemas/InstagramPreviewResponse'
       tags:
         - instagram
+    parameters:
+      - name: post_url
+        in: query
+        required: true
+        schema:
+          type: string
   /instagram/:
     post:
       operationId: instagram_create
@@ -1201,13 +1201,6 @@ components:
       type: object
       properties:
         redirect_url:
-          type: string
-    InstagramPreviewPayload:
-      type: object
-      required:
-        - post_url
-      properties:
-        post_url:
           type: string
     InstagramPreviewResponse:
       type: object


### PR DESCRIPTION
Not completed, I'm still getting the following error when hitting the preview endpoint:
GET: `/api/instagram-preview/?post_url=https%253A%252F%252Fwww.instagram.com%252Fp%252FChVkm42jYdD`
```
[2022-09-18T19:13:59.027] ERROR django.request log.py:224 | Internal Server Error: /api/instagram-preview/
Traceback (most recent call last):
  File "/Users/davidnaranjo/opt/anaconda3/envs/eas/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/Users/davidnaranjo/opt/anaconda3/envs/eas/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/davidnaranjo/opt/anaconda3/envs/eas/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/Users/davidnaranjo/opt/anaconda3/envs/eas/lib/python3.8/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/davidnaranjo/opt/anaconda3/envs/eas/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/Users/davidnaranjo/opt/anaconda3/envs/eas/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/Users/davidnaranjo/opt/anaconda3/envs/eas/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/Users/davidnaranjo/opt/anaconda3/envs/eas/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/Users/davidnaranjo/opt/anaconda3/envs/eas/lib/python3.8/site-packages/rest_framework/decorators.py", line 50, in handler
    return func(*args, **kwargs)
  File "/Users/davidnaranjo/personal/eas-backend/eas/api/views.py", line 316, in instagram_preview
    data = instagram.get_post_info(post_url)
  File "/Users/davidnaranjo/personal/eas-backend/eas/api/instagram.py", line 30, in _
    return func(*args, **kwargs)
  File "/Users/davidnaranjo/personal/eas-backend/eas/api/instagram.py", line 45, in get_post_info
    likes=media_data.likes,
AttributeError: 'Media' object has no attribute 'likes'
```