### PR TITLE
Remove deprecated setting

### DIFF
--- a/eas/settings/base.py
+++ b/eas/settings/base.py
@@ -134,8 +134,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
This will be removed in Django 5 and is now spewing warnings.