### PR TITLE
Call `resolve_scheduled_results` only if necessary

### DIFF
--- a/eas/api/models.py
+++ b/eas/api/models.py
@@ -60,6 +60,15 @@ class BaseDraw(BaseModel):
         result_obj.save()  # Should we really save here???
         return result_obj
 
+    def has_unresolved_results(self):
+        """Checks if there is any result pending resolution"""
+        for result in self.results.filter(
+            schedule_date__lte=dt.datetime.now(dt.timezone.utc)
+        ):
+            if result.value is None:
+                return True
+        return False
+
     def resolve_scheduled_results(self):
         """Resolves all scheduled results in the past"""
         for result in self.results.filter(


### PR DESCRIPTION
Calling this method will trigger a call to fetch the comments of a post for the instagram post, this will consume our quota.

Closes #173