### PR TITLE
Fix deprecated warnings on github actions

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate swagger file
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
         uses: char0n/swagger-editor-validate@v1
         with:

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -55,15 +55,16 @@ jobs:
       - name: Set vars
         id: set_vars
         run: |
-          echo "::set-output name=deployment_branch::"
+          echo "deployment_branch=" >> $GITHUB_OUTPUT
 
           if [[ "${{github.ref}}" == "refs/heads/master" ]]; then
               # if this is a push to master, deploy to dev
               if [[ "${{github.event_name}}" == "push" ]]; then
-                  echo "::set-output name=deployment_branch::master"
+                  echo "deployment_branch=master" >> $GITHUB_OUTPUT
               # If triggered manually, deply to prod
               elif [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
-                  echo "::set-output name=deployment_branch::prod"
+                  echo "deployment_branch=prod" >> $GITHUB_OUTPUT
+
               fi
           fi
   test_swagger_editor_validator_remote:


### PR DESCRIPTION
```
[set-vars](https://github.com/etcaterva/eas-backend/actions/runs/6983666903/job/19005187829#step:2:15)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

[Lint & Test (3.8)](https://github.com/etcaterva/eas-backend/actions/runs/6983666903/job/19005187702)
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-python@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

[Validate swagger file](https://github.com/etcaterva/eas-backend/actions/runs/6983666903/job/19005187945)
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```