### PR TITLE
Reduce logging output and files kept

### DIFF
--- a/eas/api/views.py
+++ b/eas/api/views.py
@@ -65,7 +65,7 @@ class BaseDrawViewSet(
         result_data = serializer.data
         if pk != result_data["private_id"]:
             self.remove_private_fields(result_data)
-        LOG.info("Returning draw %s", result_data)
+        LOG.info("Returning draw with id: %s", pk)
         return Response(result_data)
 
     @action(methods=["post"], detail=True)

--- a/eas/settings/prod.py
+++ b/eas/settings/prod.py
@@ -45,16 +45,16 @@ LOGGING = {
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "standard",
             "filename": os.path.join(BASE_LOG_PATH, "echaloasuerte_log.txt"),
-            "maxBytes": 1024 * 1024 * 200,  # 200 MB
-            "backupCount": 10,
+            "maxBytes": 1024 * 1024 * 100,  # 100 MB
+            "backupCount": 5,
         },
         "error_log_file": {
             "level": "ERROR",
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "standard",
             "filename": os.path.join(BASE_LOG_PATH, "echaloasuerte_err.txt"),
-            "maxBytes": 1024 * 1024 * 30,  # 30 MB
-            "backupCount": 5,
+            "maxBytes": 1024 * 1024 * 30,  # 50 MB
+            "backupCount": 2,
         },
     },
     "loggers": {


### PR DESCRIPTION
Reduce the amount of log we keep and remove the most noisy log line. We can see the actual result by hitting the API if needed.