### PR TITLE
Fix payment for certified draws

### DIFF
--- a/eas/api/models.py
+++ b/eas/api/models.py
@@ -344,6 +344,12 @@ class Payment(BaseModel):
     option_support = models.BooleanField(default=False)
     option_adfree = models.BooleanField(default=False)
 
+    @staticmethod
+    def fetch_payments(draw_id):
+        return Payment.objects.filter(
+            models.Q(draw_id=draw_id) | models.Q(secret_santa_id=draw_id)
+        ).order_by("-created_at")
+
     def __repr__(self):
         options_str = ""
         options_str += "Y" if self.option_certified else "N"

--- a/eas/api/views.py
+++ b/eas/api/views.py
@@ -442,10 +442,9 @@ def revolut_create(request):
 
 @api_view(["GET"])
 def revolut_accept(_, draw_id):
-    try:
-        payment = get_object_or_404(models.Payment, secret_santa_id=draw_id)
-    except Http404:
-        payment = get_object_or_404(models.Payment, draw_id=draw_id)
+    payment = models.Payment.fetch_payments(draw_id).first()
+    if payment is None:  # pragma: no cover
+        raise ValidationError("Draw ID has not payments!")
     LOG.info("Accepting payment for id %r", payment.revolut_id)
     if revolut.accept_payment(payment.revolut_id):
         payment.payed = True


### PR DESCRIPTION
If multiple payments are created for the draw, pick the last. This is a cheap dirty fix to prevent issue who are paying from paying and not getting it certified.